### PR TITLE
Switch from MiqUUID to UUIDTools

### DIFF
--- a/lib/virtfs/xfs/allocation_group.rb
+++ b/lib/virtfs/xfs/allocation_group.rb
@@ -1,5 +1,4 @@
 require 'binary_struct'
-require 'util/miq-uuid'
 require 'stringio'
 require 'memory_buffer'
 require 'fs/xfs/superblock'

--- a/lib/virtfs/xfs/bmap_btree_block.rb
+++ b/lib/virtfs/xfs/bmap_btree_block.rb
@@ -1,5 +1,4 @@
 require 'binary_struct'
-require 'util/miq-uuid'
 require 'stringio'
 
 require 'rufus/lru'

--- a/lib/virtfs/xfs/superblock.rb
+++ b/lib/virtfs/xfs/superblock.rb
@@ -203,7 +203,7 @@ module XFS
       @allocation_group_blocks          = @sb['ag_blocks']
       @groups_count, @last_group_blocks = @sb['data_blocks'].divmod(@allocation_group_blocks)
       @groups_count += 1 if @last_group_blocks > 0
-      @filesystem_id                    = MiqUUID.parse_raw(@sb['uuid'])
+      @filesystem_id                    = UUIDTools::UUID.parse_raw(@sb['uuid'])
       @volume_name                      = @sb['fs_name']
       @ialloc_inos                      = (@sb['inodes_per_blk']..XFS_INODES_PER_CHUNK).max
       @ialloc_blks                      = @ialloc_inos >> @sb['inodes_per_blk_log']

--- a/lib/virtfs/xfs/superblock.rb
+++ b/lib/virtfs/xfs/superblock.rb
@@ -7,6 +7,7 @@ require 'memory_buffer'
 require 'fs/xfs/allocation_group'
 require 'fs/xfs/inode_map'
 require 'fs/xfs/inode'
+require 'uuidtools'
 
 require 'rufus/lru'
 

--- a/lib/virtfs/xfs/superblock.rb
+++ b/lib/virtfs/xfs/superblock.rb
@@ -1,7 +1,6 @@
 # encoding: US-ASCII
 
 require 'binary_struct'
-require 'util/miq-uuid'
 require 'stringio'
 require 'memory_buffer'
 require 'fs/xfs/allocation_group'

--- a/virtfs-xfs.gemspec
+++ b/virtfs-xfs.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency("uuidtools", "~> 2.2")
+
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This updates the code to use uuidtools instead of miq-uuid, which is being removed from gems-pending. As it stands the `MiqUUID.parse_raw` call would not work anyway.

I also updated the gemspec to add the uuidtools dependency, and loosen the version requirements for bundler and rake (we should not care).