### PR TITLE
Remove deprecated codeclimate gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 cache: bundler
 language: ruby
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,9 @@ language: ruby
 rvm:
   - 2.3.1
 before_install: gem install bundler -v 1.12.5
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", :require => false
   gem "simplecov", :require => false
 end


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

it's marked work in progress because it depends on the addition of the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779

the second commit: 
we can get rid of `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

@miq-bot add_label dependencies, test, cleanup 
@miq-bot assign @Fryguy 